### PR TITLE
Support multiple item types. Can be left empty instead of -1.

### DIFF
--- a/PluginAppLoader/apploader.h
+++ b/PluginAppLoader/apploader.h
@@ -25,16 +25,16 @@ class tAppMenu;
 /// Hold information related to an action for sorting purposes
 class tAppAction {
 public:
-    tAppAction(QAction *action, double priority, tAppMenu *app, int type=-1):
+    tAppAction(QAction *action, double priority, tAppMenu *app, QList<int> types={}):
         Priority(priority),
-        TypeShowOnContextMenu(type),
+        TypesShowOnContextMenu(types),
         AppMenu(app)
     {
         Action = action;
     }
     QAction *Action;
     double Priority;
-    int TypeShowOnContextMenu;
+    QList<int> TypesShowOnContextMenu;
     tAppMenu *AppMenu;
 };
 


### PR DESCRIPTION
Support multiple item types for context menu. 
Setting can be left empty instead of -1.

Examples: 
1. TypeContextMenu=
2. TypeContextMenu=-1
3. TypeContextMenu=5
4. TypeContextMenu=5,6,7